### PR TITLE
[IRON-14173] - Make updates to force scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pactsafe/pactsafe-react-sdk",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pactsafe/pactsafe-react-sdk",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pactsafe/pactsafe-react-sdk",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Ironclad Clickwrap React SDK - SDK for easy Ironclad Clickwrap implementations leveraging the Ironclad JavaScript Library & API",
   "author": "Ironclad",
   "license": "MIT",

--- a/src/PSClickWrap.js
+++ b/src/PSClickWrap.js
@@ -216,16 +216,16 @@ class PSClickWrap extends React.Component {
     } = this.props;
     const options = {
       allow_disagreed: allowDisagreed || false,
-      ...(acceptanceLanguage && { acceptance_language: acceptanceLanguage }),
+      ...(acceptanceLanguage !== undefined && { acceptance_language: acceptanceLanguage }),
       auto_run: displayImmediately,
-      ...(confirmationEmail && { confirmation_email: confirmationEmail }),
+      ...(confirmationEmail !== undefined && { confirmation_email: confirmationEmail }),
       container_selector: containerId,
       display_all: displayAll,
-      ...(filter && { filter }),
-      ...(forceScroll && { force_scroll: forceScroll }),
-      ...(renderData && { render_data: renderData }),
-      ...(signerIdSelector && { signer_id_selector: signerIdSelector }),
-      ...(clickWrapStyle && { style: clickWrapStyle }),
+      ...(filter !== undefined && { filter }),
+      ...(forceScroll !== undefined && { force_scroll: forceScroll }),
+      ...(renderData !== undefined && { render_data: renderData }),
+      ...(signerIdSelector !== undefined && { signer_id_selector: signerIdSelector }),
+      ...(clickWrapStyle !== undefined && { style: clickWrapStyle }),
     };
 
     if (injectSnippetOnly) return;

--- a/src/PSClickWrap.js
+++ b/src/PSClickWrap.js
@@ -96,7 +96,7 @@ class PSClickWrap extends React.Component {
       && !dynamicGroup
       && _psLoadedValidGroup
     ) {
-      _ps.getByKey(clickwrapGroupKey).site.set('style', clickWrapStyle);
+      _ps.getByKey(clickwrapGroupKey).set('style', clickWrapStyle);
       _ps.getByKey(clickwrapGroupKey).retrieveHTML();
     }
     if (!isEqual(customData, prevProps.customData)) {
@@ -106,11 +106,11 @@ class PSClickWrap extends React.Component {
       _ps('set', 'acceptance_language', acceptanceLanguage);
     }
     if (!isEqual(renderData, prevProps.renderData)) {
-      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).site.set('style', clickWrapStyle); }
+      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).set('style', clickWrapStyle); }
       _ps(`${clickwrapGroupKey}:retrieveHTML`, renderData);
     }
     if (signerId !== prevProps.signerId) {
-      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).site.set('style', clickWrapStyle); }
+      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).set('style', clickWrapStyle); }
       _ps('set', 'signer_id', signerId);
     }
     if (clickWrapStyle !== prevProps.clickWrapStyle && dynamicGroup) {
@@ -216,16 +216,16 @@ class PSClickWrap extends React.Component {
     } = this.props;
     const options = {
       allow_disagreed: allowDisagreed || false,
-      acceptance_language: acceptanceLanguage,
+      ...(acceptanceLanguage && { acceptance_language: acceptanceLanguage }),
       auto_run: displayImmediately,
-      confirmation_email: confirmationEmail,
+      ...(confirmationEmail && { confirmation_email: confirmationEmail }),
       container_selector: containerId,
       display_all: displayAll,
-      filter,
-      force_scroll: forceScroll,
-      render_data: renderData,
-      signer_id_selector: signerIdSelector,
-      style: clickWrapStyle,
+      ...(filter && { filter }),
+      ...(forceScroll && { force_scroll: forceScroll }),
+      ...(renderData && { render_data: renderData }),
+      ...(signerIdSelector && { signer_id_selector: signerIdSelector }),
+      ...(clickWrapStyle && { style: clickWrapStyle }),
     };
 
     if (injectSnippetOnly) return;

--- a/src/PSClickWrap.js
+++ b/src/PSClickWrap.js
@@ -96,7 +96,7 @@ class PSClickWrap extends React.Component {
       && !dynamicGroup
       && _psLoadedValidGroup
     ) {
-      _ps.getByKey(clickwrapGroupKey).set('style', clickWrapStyle);
+      _ps.getByKey(clickwrapGroupKey).site.set('style', clickWrapStyle);
       _ps.getByKey(clickwrapGroupKey).retrieveHTML();
     }
     if (!isEqual(customData, prevProps.customData)) {
@@ -106,11 +106,11 @@ class PSClickWrap extends React.Component {
       _ps('set', 'acceptance_language', acceptanceLanguage);
     }
     if (!isEqual(renderData, prevProps.renderData)) {
-      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).set('style', clickWrapStyle); }
+      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).site.set('style', clickWrapStyle); }
       _ps(`${clickwrapGroupKey}:retrieveHTML`, renderData);
     }
     if (signerId !== prevProps.signerId) {
-      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).set('style', clickWrapStyle); }
+      if (clickWrapStyle && _psLoadedValidGroup) { _ps.getByKey(clickwrapGroupKey).site.set('style', clickWrapStyle); }
       _ps('set', 'signer_id', signerId);
     }
     if (clickWrapStyle !== prevProps.clickWrapStyle && dynamicGroup) {


### PR DESCRIPTION
[IRON-14173](https://ironcladapp.atlassian.net/browse/IRON-14173)

Bug fix for force scroll. Issue would arise when the prop wasn't passed in for a group, but it was set on the group settings. The prop would result in passing back something like `force_scroll: undefined`, which would conflict with the group setting. The changes include clearing out fields that are `undefined` from the group options.

Also making an update to fix behavior attached to a [change](https://ironcladapp.atlassian.net/browse/IRON-14545) for retrieveHTML. This would alter the behavior of `retrieveHTML`, so that it wouldn't reset virtual group properties. But the React SDK depends on that behavior right now to pull settings from the site. 


[IRON-14173]: https://ironcladapp.atlassian.net/browse/IRON-14173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ