### PR TITLE
[IRON-14173] - Undo manual version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pactsafe/pactsafe-react-sdk",
-  "version": "2.9.0",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pactsafe/pactsafe-react-sdk",
-      "version": "2.9.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pactsafe/pactsafe-react-sdk",
-  "version": "2.9.0",
+  "version": "2.8.0",
   "description": "Ironclad Clickwrap React SDK - SDK for easy Ironclad Clickwrap implementations leveraging the Ironclad JavaScript Library & API",
   "author": "Ironclad",
   "license": "MIT",


### PR DESCRIPTION
The package version gets bumped by `np`, so didn't need to manually bump it up. 