### PR TITLE
Move `dotenv-webpack` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "classnames": "^2.3.2",
-    "dotenv-webpack": "^8.0.1",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.8.1",
     "react-proptype-conditional-require": "^1.0.4",
@@ -46,6 +45,7 @@
     "@babel/preset-react": "^7.18.6",
     "babel-jest": "^29.0.3",
     "babel-plugin-search-and-replace": "^1.1.1",
+    "dotenv-webpack": "^8.0.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "enzyme-to-json": "^3.6.2",


### PR DESCRIPTION
Currently `dotenv-webpack` library is listed as a dependency in `package.json`. Because of this `pactsafe-react-sdk` library consumers have `webpack` in their `node_modules/` folder even if they don't use it as a build tool.

This pr just moves `dotenv-webpack` to devDependencies, where it should be.