### PR TITLE
Removed enzyme and replaced with @testing-library/react

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: 'Tests'
+on:
+  pull_request:
+    types: [opened, synchronize] # `reopened` could work here too, but it sometimes fires at the same time as synchronize
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: 'Run Tests'
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: npm ci 
+      - name: Run tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,11 @@
         "@babel/plugin-proposal-export-default-from": "^7.18.10",
         "@babel/preset-env": "^7.19.1",
         "@babel/preset-react": "^7.18.6",
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^11.2.7",
         "babel-jest": "^29.0.3",
         "babel-plugin-search-and-replace": "^1.1.1",
         "dotenv-webpack": "^8.0.1",
-        "enzyme": "^3.11.0",
-        "enzyme-adapter-react-16": "^1.15.6",
-        "enzyme-to-json": "^3.6.2",
         "eslint": "^8.23.1",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-plugin-import": "^2.26.0",
@@ -57,6 +56,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -2096,6 +2101,25 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.2.tgz",
+      "integrity": "sha512-54cIh74Z1rp4oIjsHjqN+WM4fMyCBYe+LpZ9jWm51CZ1fbH3SkAzQD/3XLoNkjbJ7YEmjobLXyvQrFypRHOrXw==",
+      "dev": true,
+      "dependencies": {
+        "core-js-pure": "^3.30.2",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
+    },
     "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "dev": true,
@@ -2966,6 +2990,166 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "7.31.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.6",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/@jest/types": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/@types/yargs": {
+      "version": "15.0.18",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.18.tgz",
+      "integrity": "sha512-DDi2KmvAnNsT/EvU8jp1UR7pOJojBtJ3GLZ/uw1MUq4VbbESppPWoHUY4h0OB4BbEbGJiyEsmUcuZDZtoR+ZwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
+      "integrity": "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.0.1",
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
+      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "dev": true,
@@ -2973,6 +3157,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.4",
@@ -3022,14 +3212,6 @@
         "@types/responselike": "^1.0.0"
       }
     },
-    "node_modules/@types/cheerio": {
-      "version": "0.22.34",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "dev": true,
@@ -3076,6 +3258,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.8.tgz",
+      "integrity": "sha512-fXEFTxMV2Co8ZF5aYFJv+YeA08RTYJfhtN5c9JSv/mFEMe+xxjufCb+PHL+bJcMs/ebPUsBu+UNTEz+ydXrR6g==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {
@@ -3156,6 +3348,15 @@
       "version": "1.0.11",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/testing-library__jest-dom": {
+      "version": "5.14.9",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
+      "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -3617,28 +3818,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "dev": true,
@@ -3908,38 +4087,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array.prototype.filter": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.find": {
-      "version": "2.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.findlastindex": {
@@ -5533,42 +5680,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/chokidar": {
       "version": "2.1.8",
       "dev": true,
@@ -6537,6 +6648,17 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.2.tgz",
+      "integrity": "sha512-a8zeCdyVk7uF2elKIGz67AjcXOxjRbwOLz8SbklEso1V+2DoW4OkAMZN9S9GBgvZIaqQi/OemFX4OiSoQEmg1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "dev": true,
@@ -6774,21 +6896,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/css-select-base-adapter": {
       "version": "0.1.1",
       "dev": true,
@@ -6816,6 +6923,12 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -7547,11 +7660,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/dns-equal": {
       "version": "1.0.0",
       "dev": true,
@@ -7585,6 +7693,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
+    },
     "node_modules/dom-converter": {
       "version": "0.2.0",
       "dev": true,
@@ -7602,19 +7716,6 @@
         "ent": "~2.2.0",
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
-      }
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/domain-browser": {
@@ -7646,33 +7747,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-case": {
@@ -7952,126 +8026,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/enzyme": {
-      "version": "3.11.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flat": "^1.2.3",
-        "cheerio": "^1.0.0-rc.3",
-        "enzyme-shallow-equal": "^1.0.1",
-        "function.prototype.name": "^1.1.2",
-        "has": "^1.0.3",
-        "html-element-map": "^1.2.0",
-        "is-boolean-object": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-number-object": "^1.0.4",
-        "is-regex": "^1.0.5",
-        "is-string": "^1.0.5",
-        "is-subset": "^0.1.1",
-        "lodash.escape": "^4.0.1",
-        "lodash.isequal": "^4.5.0",
-        "object-inspect": "^1.7.0",
-        "object-is": "^1.0.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1",
-        "object.values": "^1.1.1",
-        "raf": "^3.4.1",
-        "rst-selector-parser": "^2.2.3",
-        "string.prototype.trim": "^1.2.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16": {
-      "version": "1.15.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "enzyme-adapter-utils": "^1.14.1",
-        "enzyme-shallow-equal": "^1.0.5",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.4",
-        "object.values": "^1.1.5",
-        "prop-types": "^15.8.1",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.0.0",
-        "react": "^16.0.0-0",
-        "react-dom": "^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/enzyme-adapter-utils": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.5",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.4",
-        "object.fromentries": "^2.0.5",
-        "prop-types": "^15.8.1",
-        "semver": "^5.7.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-utils/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/enzyme-shallow-equal": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3",
-        "object-is": "^1.1.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/enzyme-to-json": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cheerio": "^0.22.22",
-        "lodash": "^4.17.21",
-        "react-is": "^16.12.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.4.0"
       }
     },
     "node_modules/errno": {
@@ -10238,18 +10192,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/html-element-map": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.filter": "^1.0.0",
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "dev": true,
@@ -10319,24 +10261,6 @@
       },
       "peerDependencies": {
         "webpack": ">=4.0.0 < 6.0.0"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -11730,11 +11654,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-subset": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -13752,16 +13671,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.escape": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "license": "MIT"
@@ -14002,6 +13911,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "dev": true,
@@ -14212,6 +14130,15 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -14641,11 +14568,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "dev": true,
@@ -14779,27 +14701,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -17892,18 +17793,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.2",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parseqs": {
       "version": "0.0.6",
       "dev": true,
@@ -18802,16 +18691,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-exact": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "dev": true,
@@ -19013,31 +18892,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/randombytes": {
@@ -19462,6 +19316,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "dev": true,
@@ -19480,11 +19356,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/reflect.ownkeys": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -20002,15 +19873,6 @@
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "node_modules/rst-selector-parser": {
-      "version": "2.2.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
       }
     },
     "node_modules/run-applescript": {
@@ -21329,6 +21191,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,11 @@
     "@babel/plugin-proposal-export-default-from": "^7.18.10",
     "@babel/preset-env": "^7.19.1",
     "@babel/preset-react": "^7.18.6",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^11.2.7",
     "babel-jest": "^29.0.3",
     "babel-plugin-search-and-replace": "^1.1.1",
     "dotenv-webpack": "^8.0.1",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.6",
-    "enzyme-to-json": "^3.6.2",
     "eslint": "^8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.26.0",
@@ -76,12 +75,6 @@
     "url": "https://github.com/PactSafe/pactsafe-react-sdk/issues"
   },
   "jest": {
-    "setupFiles": [
-      "./tests/jest-setup.js"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ],
     "transform": {
       "^.+\\.js$": "<rootDir>/jest.transform.js"
     },

--- a/tests/PSClickWrap.test.js
+++ b/tests/PSClickWrap.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom'; // for assertion methods like toBeInTheDocument
 import { PSClickWrap } from '../src';
 
 // Index of function call order in mock object.
@@ -12,7 +13,7 @@ const FUNC = Object.freeze({
 
 describe('_ps initialization', () => {
   it('Creates _ps runner global', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" displayAll testMode />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" displayAll testMode />);
     expect(_ps).toBeDefined();
   });
 });
@@ -20,47 +21,52 @@ describe('_ps initialization', () => {
 describe('PSClickWrap _ps interface tests', () => {
   beforeEach(() => {
     window._ps = jest.fn();
+    
+    // Reload Snippet between tests
+    Array.from(document.getElementsByTagName('script')).forEach((s) => s.parentNode.removeChild(s));
   });
 
   it('Renders a ps-clickwrap wrapper div', () => {
-    const wrapper = mount(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" />);
-    expect(wrapper.containsMatchingElement(<div id="ps-clickwrap" />)).toBeTruthy();
+    const { container } = render(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" />);
+    const psClickwrapDiv = container.querySelector('#ps-clickwrap');
+    expect(psClickwrapDiv).toBeInTheDocument();
   });
 
   it('Renders a container div with specified container Id if passed as a prop', () => {
-    const wrapper = mount(<PSClickWrap accessId="0000000-000000-0000-0000000" containerId="test" signerIdSelector="email" groupKey="example-clickwrap" />);
-    expect(wrapper.containsMatchingElement(<div id="test" />)).toBeTruthy();
+    const { container } = render(<PSClickWrap accessId="0000000-000000-0000-0000000" containerId="test" signerIdSelector="email" groupKey="example-clickwrap" />);
+    const psClickwrapDiv = container.querySelector('#test');
+    expect(psClickwrapDiv).toBeInTheDocument();
   });
 
   it('calls _ps with create and proper access ID', () => {
     const passedAccessId = '29ea80d9-d386-4cfd-a280-505e802ee732';
-    mount(<PSClickWrap accessId={passedAccessId} signerIdSelector="email" groupKey="example-clickwrap" displayAll testMode />);
+    render(<PSClickWrap accessId={passedAccessId} signerIdSelector="email" groupKey="example-clickwrap" displayAll testMode />);
     expect(_ps.mock.calls[FUNC.CREATE][0]).toBe('create');
     expect(_ps.mock.calls[FUNC.CREATE][1]).toBe(passedAccessId);
   });
 
   it('calls _ps create with test_mode if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" testMode />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" testMode />);
     expect(_ps.mock.calls[FUNC.CREATE][2].test_mode).toBe(true);
   });
 
   it('calls _ps create with disable_sending if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" disableSending />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" disableSending />);
     expect(_ps.mock.calls[FUNC.CREATE][2].disable_sending).toBe(true);
   });
 
   it('calls _ps create with dynamic in payload if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" dynamic renderData={{}} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" signerIdSelector="email" groupKey="example-clickwrap" dynamic renderData={{}} />);
     expect(_ps.mock.calls[FUNC.CREATE][2].dynamic).toBe(true);
   });
 
   it('calls _ps with signer id specified in create payload if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.CREATE][2].signer_id).toBe('test@abc.com');
   });
 
   it('_ps create passes in test_mode, disable_sending, dynamic, and signer_id as options', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.CREATE][2]).toHaveProperty('test_mode');
     expect(_ps.mock.calls[FUNC.CREATE][2]).toHaveProperty('disable_sending');
     expect(_ps.mock.calls[FUNC.CREATE][2]).toHaveProperty('dynamic');
@@ -68,13 +74,13 @@ describe('PSClickWrap _ps interface tests', () => {
   });
 
   it('calls _ps load with specified group key', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][0]).toBe('load');
     expect(_ps.mock.calls[FUNC.LOAD][1]).toBe('example-clickwrap');
   });
 
   it('calls _ps with options as second parameter if filter is specified, makes sure filter is passed propertly', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" filter="id==12345 and tags==tag1,tag2" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" filter="id==12345 and tags==tag1,tag2" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][0]).toBe('load');
     expect(typeof _ps.mock.calls[FUNC.LOAD][1]).toBe('object');
     expect(_ps.mock.calls[FUNC.LOAD][1]).toHaveProperty('filter');
@@ -92,7 +98,7 @@ describe('PSClickWrap _ps interface tests', () => {
   });
 
   it('calls _ps with options as third parameter if groupKey is specified', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][0]).toBe('load');
     expect(typeof _ps.mock.calls[FUNC.LOAD][2]).toBe('object');
     expect(_ps.mock.calls[FUNC.LOAD][2]).toHaveProperty('container_selector');
@@ -109,126 +115,126 @@ describe('PSClickWrap _ps interface tests', () => {
   });
 
   it('sets clickwrapStyle properly on payload if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" clickWrapStyle="scroll" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" clickWrapStyle="scroll" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].style).toBe('scroll');
   });
 
   it('leaves clickwrapStyle to be undefined if not passed prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].style).toBeUndefined();
   });
 
   it('sets confirmationEmail property to true on payload if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" confirmationEmail />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" confirmationEmail />);
     expect(_ps.mock.calls[FUNC.LOAD][2].confirmation_email).toBe(true);
   });
 
   it('leaves confirmationEmail as undefined if not passed as prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].confirmation_email).toBeUndefined();
   });
 
   it('sets disableSending to true if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" disableSending />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" disableSending />);
     expect(_ps.mock.calls[FUNC.CREATE][2].disable_sending).toBe(true);
   });
 
   it('defaults disableSending to false if not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.CREATE][2].disable_sending).toBe(false);
   });
 
   it('defaults displayAll to true if not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].display_all).toBe(true);
   });
 
   it('sets displayAll to value passed as prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" displayAll={false} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" displayAll={false} />);
     expect(_ps.mock.calls[FUNC.LOAD][2].display_all).toBe(false);
   });
 
   it('sets auto_run to true by default if not passing displayImmediately to false', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].auto_run).toBe(true);
   });
 
   it('sets auto_run to false if passing displayImmediately=false as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" displayImmediately={false} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" displayImmediately={false} />);
     expect(_ps.mock.calls[FUNC.LOAD][2].auto_run).toBe(false);
   });
 
   it('sets dynamic to true in create call if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" dynamic renderData={{}} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" dynamic renderData={{}} />);
     expect(_ps.mock.calls[FUNC.CREATE][2].dynamic).toBe(true);
   });
 
   it('defaults to dynamic as false if not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.CREATE][2].dynamic).toBe(false);
   });
 
   it('defaults force_scroll to undefined if not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].force_scroll).toBe(undefined);
   });
 
   it('ensures renderData is passed properly if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" renderData={{ test: 'abc' }} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" renderData={{ test: 'abc' }} />);
     expect(_ps.mock.calls[FUNC.LOAD][2].render_data).toMatchObject({ test: 'abc' });
   });
 
   it('sets renderData to undefined if it is not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].render_data).toBeUndefined();
   });
 
   it('sets testMode to true if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" testMode />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" testMode />);
     expect(_ps.mock.calls[FUNC.CREATE][2].test_mode).toBe(true);
   });
 
   it('sets testMode to false if not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.CREATE][2].test_mode).toBe(false);
   });
 
   it('sets allowDisagreed to true if passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" allowDisagreed />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" allowDisagreed />);
     expect(_ps.mock.calls[FUNC.LOAD][2].allow_disagreed).toBe(true);
   });
 
   it('a console error should be shown if onInvalid is passed without setting allowDisagreed', () => {
     const logSpy = jest.spyOn(console, 'error');
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" onInvalid={() => {}} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" onInvalid={() => {}} />);
     expect(logSpy).toHaveBeenCalled();
   });
 
   it('client properties should be set to react', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" onInvalid={() => {}} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" onInvalid={() => {}} />);
     expect(_ps.mock.calls[FUNC.SET_LIB][2]).toBe('react-sdk');
     expect(_ps.mock.calls[FUNC.SET_VER][2]).toBe('_client-version');
   });
 
   it('ensures customData is passed properly if passed as a prop', () => {
     const testCustomData = { key_1: 'key1val', key_2: 2 };
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" customData={testCustomData} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" customData={testCustomData} />);
     expect(_ps.mock.calls[3][2]).toMatchObject(testCustomData);
   });
 
   it('sets customData to undefined if it is not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].custom_data).toBeUndefined();
   });
 
   it('ensures acceptanceLanguage is passed properly if passed as a prop', () => {
     const testAcceptanceLanguage = 'I agree to these contracts here';
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" acceptanceLanguage={testAcceptanceLanguage} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" acceptanceLanguage={testAcceptanceLanguage} />);
     expect(_ps.mock.calls[FUNC.LOAD][2].acceptance_language).toBe(testAcceptanceLanguage);
   });
 
   it('sets acceptanceLanguage to be undefined if it is not passed as a prop', () => {
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" />);
     expect(_ps.mock.calls[FUNC.LOAD][2].acceptance_language).toBeUndefined();
   });
 });
@@ -259,23 +265,28 @@ describe('PSClickWrap _ps event prop tests', () => {
       });
     });
     window._ps.on = jest.fn();
+    window._ps.off = jest.fn();
+
+    // Needed to force the loaded snippet to not override our _ps mocks
+    window._ps.realThang = 317;
+    window._ps.loaded = true;
   });
+
+  function testPSOnParameter(psEvent) {
+    const callbackProp = { [psEvent]: () => `${psEvent} dummy callback event` };
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" {...callbackProp} />);
+    expect(_ps.on.mock.calls[0][0]).toBe(propsEventMap[psEvent]);
+  }
 
   function testPassedEventListenerCalled(psEvent) {
     const testingGroupKey = 'example-clickwrap';
     const eventCallback = {
       [psEvent]: jest.fn(),
     };
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey={testingGroupKey} signerId="test@abc.com" {...eventCallback} />);
+    render(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey={testingGroupKey} signerId="test@abc.com" {...eventCallback} />);
     const callbackRegistered = _ps.on.mock.calls[0][1];
     callbackRegistered({ get: () => testingGroupKey });
     expect(eventCallback[psEvent]).toHaveBeenCalled();
-  }
-
-  function testPSOnParameter(psEvent) {
-    const callbackProp = { [psEvent]: () => `${psEvent} dummy callback event` };
-    mount(<PSClickWrap accessId="0000000-000000-0000-0000000" groupKey="example-clickwrap" signerId="test@abc.com" {...callbackProp} />);
-    expect(_ps.on.mock.calls[0][0]).toBe(propsEventMap[psEvent]);
   }
 
   Object.keys(propsEventMap).forEach((prop) => {

--- a/tests/jest-setup.js
+++ b/tests/jest-setup.js
@@ -1,4 +1,0 @@
-import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-// React 16 Enzyme adapter
-Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
Removed `enzyme` related tests and replaced with `@testing-library`

Only real thing to note here is that previously there were some interesting side affects getting carried through the tests, as we only ever forced the JS library to be injected a single time (because jest uses the same global window object per-file rather than per test block). By clearing the script, we can now force the lib to be reloaded each time.