### PR TITLE
[IRON-28652] workaround for openssl bug with nwb + webpack 4

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,3 +1,4 @@
+const { LoaderOptionsPlugin } = require('webpack');
 const Dotenv = require('dotenv-webpack');
 const { version } = require('./package.json');
 
@@ -19,6 +20,13 @@ module.exports = {
     extra: {
       plugins: [
         new Dotenv(),
+        new LoaderOptionsPlugin({
+          options: {
+            experiments: {
+              futureDefaults: true,
+            },
+          },
+        }),
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "module": "es/index.js",
   "homepage": "https://github.com/PactSafe/pactsafe-react-sdk",
   "scripts": {
-    "build": "nwb build-react-component",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
     "prepublishOnly": "npm run build",
-    "start": "nwb serve-react-demo",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider nwb serve-react-demo",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
# [IRON-28652](https://ironcladapp.atlassian.net/browse/IRON-28652)

## Description
`nwb` (which is responsible for the build process) installs + relies on `webpack@4.43.0` ... that version of webpack has an OpenSSL issue on Node.js 18.x+

We can't just override to a newer version of `webpack` without breaking `nwb`, so we just have to pass the flag `NODE_OPTIONS=--openssl-legacy-provider` to the build commands in `package.json` until `nwb` upgrades to `webpack@5.x+`. 

## Manual Testing
- Confirmed that `./node_modules/.bin/np --preview --any-branch` (aka `npm run release`) runs successfully... as a dry run obviously
- Confirmed that `npm run build` runs successfully with the flag set

[IRON-28652]: https://ironcladapp.atlassian.net/browse/IRON-28652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ