### PR TITLE
Add loadEventCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For accounts at `app.demo.pactsafe.com`, set the `psScriptUrl` prop as `//vault.
 |     `snapshotLocation`     | Ironclad Clickwrap Snapshot Location Key, this is found within the Snapshot Location configuration                                                                                                                                                                                                                                                                             |                                    string                                    |                      No                     |                   undefined                  |
 |      `testMode`      | Enable this to register any contract acceptances as test data that can be cleared within the Ironclad Clickwrap UI                                                                                                                                                                                                                                                                           |                                     bool                                     |                      No                     |                     false                    |
 |      `allowDisagreed`      | Enable this to allow invalid events to be triggered when a signer unchecks a checkbox.                                                                         |                                     bool                                     |                   Required to be true if `onInvalid` is passed                      |                     Value specified in Ironclad Clickwrap Group's UI                    |
+|        `onLoadCallback`       | See [onLoadCallback](#onLoadCallback) below                                                                                                                                                                                                                                                                                                                                                          |                                   function                                   |                      No                     |                   undefined                  |
 |        `onAll`       | See [onAll](#onAll) below                                                                                                                                                                                                                                                                                                                                                          |                                   function                                   |                      No                     |                   undefined                  |
 |       `onSent`       | See [onSent](#onSent) below                                                                                                                                                                                                                                                                                                                                                        |                                   function                                   |                      No                     |                   undefined                  |
 |     `onRetrieved`    | See [onRetrieved](#onRetrieved) below                                                                                                                                                                                                                                                                                                                                              |                                   function                                   |                      No                     |                   undefined                  |
@@ -182,11 +183,24 @@ If you do not want to use event callback props, the `_ps` is loaded into the win
 
 The list below describes the props names and corresponding Ironclad Clickwrap events:
 
+## <a name="onLoadCallback"></a> onLoadCallback
+
+_ps event: n/a
+
+A callback that can be added specifically for the load event which is not included in the default set of events below. The first argument is an object containing an error if detected and null otherwise. The remaining arguments will match the arguments were passed to the original event's callback function.
+
+### Callback Arguments
+
+|       Name       |        Type        |                   Description                                                                                                                       |
+|:----------------:|:------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------:|
+| err            | Object             | An object containing the error if detected; null otherwise.                                                                                                           |
+|[arguments]       | Array<Any>         | The arguments passed to the original load event.                                                                                        |
+
 ## <a name="onAll"></a> onAll
 
 _ps event: `all`
 
-A special event that is triggered when any other event is triggered. The name of the original event is always the first argument passed to the callback function. The rest of the arguments will match whatever arguments were passed to the original event's callback function.
+A special event that is triggered when any event below is triggered (note that this does not include the onLoadCallback event). The name of the original event is always the first argument passed to the callback function. The rest of the arguments will match whatever arguments were passed to the original event's callback function.
 
 ### Callback Arguments
 

--- a/src/PSClickWrap.js
+++ b/src/PSClickWrap.js
@@ -220,6 +220,7 @@ class PSClickWrap extends React.Component {
       signerIdSelector,
       snapshotLocation,
       allowDisagreed,
+			loadEventCallback,
     } = this.props;
     const options = {
       ...(allowDisagreed !== undefined && { allow_disagreed: allowDisagreed }),
@@ -255,6 +256,7 @@ class PSClickWrap extends React.Component {
         if (!isDynamic) group.render();
         this.registerEventListeners(key);
       }
+			loadEventCallback && loadEventCallback(err, group);
     };
 
     if (customData) {
@@ -334,6 +336,7 @@ PSClickWrap.propTypes = {
     (props) => props.hasOwnProperty('onInvalid'),
     PSClickWrap.MUST_SET_ALLOW_DISAGREED,
   ),
+	loadEventCallback: PropTypes.func,
   debug: PropTypes.bool,
   onAll: PropTypes.func,
   onSent: PropTypes.func,

--- a/src/PSClickWrap.js
+++ b/src/PSClickWrap.js
@@ -220,7 +220,7 @@ class PSClickWrap extends React.Component {
       signerIdSelector,
       snapshotLocation,
       allowDisagreed,
-			loadEventCallback,
+      onLoadCallback,
     } = this.props;
     const options = {
       ...(allowDisagreed !== undefined && { allow_disagreed: allowDisagreed }),
@@ -256,7 +256,7 @@ class PSClickWrap extends React.Component {
         if (!isDynamic) group.render();
         this.registerEventListeners(key);
       }
-			loadEventCallback && loadEventCallback(err, group);
+      onLoadCallback && onLoadCallback(err, group);
     };
 
     if (customData) {
@@ -336,7 +336,7 @@ PSClickWrap.propTypes = {
     (props) => props.hasOwnProperty('onInvalid'),
     PSClickWrap.MUST_SET_ALLOW_DISAGREED,
   ),
-	loadEventCallback: PropTypes.func,
+  onLoadCallback: PropTypes.func,
   debug: PropTypes.bool,
   onAll: PropTypes.func,
   onSent: PropTypes.func,


### PR DESCRIPTION
The JS SDK allows for a callback on certain methods. Since the React SDK handles `_ps("load")` under the hood we need allow users to specify an error handling callback for this method.

Verified locally.